### PR TITLE
Fix persistent `true` value on IsMultipleGameInstancesAllowed option after relaunch

### DIFF
--- a/Nitrox.Launcher/ViewModels/MainWindowViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/MainWindowViewModel.cs
@@ -90,10 +90,10 @@ internal partial class MainWindowViewModel : ViewModelBase, IRoutingScreen
             if (!NitroxEnvironment.IsReleaseMode)
             {
                 // Set debug default options here.
+                keyValueStore.SetIsMultipleGameInstancesAllowed(true);
                 LauncherNotifier.Info("You're now using Nitrox Unlocked DEV build");
             }
-            keyValueStore.SetIsMultipleGameInstancesAllowed(true);
-
+            
             Task.Run(async () =>
             {
                 if (!NetHelper.HasInternetConnectivity())


### PR DESCRIPTION
Fixed: `Allow Multiple Game Instances` always turned to ON after relaunching.

**steps to reproduce the issue:**
1. open nitrox unlocked launcher
2. set `Allow Multiple Game Instances` from ON to OFF.
3. close the launcher
4. open the launcher again
5. check the options, the value keep getting set back to ON.
note: same thing happen if we modified the config file in `~/.config/Nitrox/nitrox.cfg`

this change is based on following the non-pirated Nitrox mod [MainWindowViewModel.cs #L92-L97](https://github.com/SubnauticaNitrox/Nitrox/blob/master/Nitrox.Launcher/ViewModels/MainWindowViewModel.cs#L92-L97)