### PR TITLE
Revert "Fix persistent `true` value on IsMultipleGameInstancesAllowed option after relaunch"

### DIFF
--- a/Nitrox.Launcher/ViewModels/MainWindowViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/MainWindowViewModel.cs
@@ -92,10 +92,10 @@ internal partial class MainWindowViewModel : ViewModelBase, IRoutingScreen
             if (!NitroxEnvironment.IsReleaseMode)
             {
                 // Set debug default options here.
-                keyValueStore.SetIsMultipleGameInstancesAllowed(true);
                 LauncherNotifier.Info("You're now using Nitrox Unlocked DEV build");
             }
-            
+            keyValueStore.SetIsMultipleGameInstancesAllowed(true);
+
             Task.Run(async () =>
             {
                 if (!NetHelper.HasInternetConnectivity())


### PR DESCRIPTION
Reverts Papela/Nitrox-Cracked-Mod#99
The PR disables the "Allow multiple game instances" option by default, requiring it to be enabled to play unofficial versions.